### PR TITLE
fix: invalid operators

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ historyDisplay.style.display = "none";
 display.value = "0";
 
 function verification(displayText, new_caracter) {
-  if (displayText === "" && (new_caracter === '*' || new_caracter === '/')) {
+  if (displayText === "" && (new_caracter === '*' || new_caracter === '/' || new_caracter === '+' || new_caracter === '-')) {
     return displayText;
   }
 


### PR DESCRIPTION
Fixes #71

There is already a function that handles this issue. 
But the above function was only written for '*', and '/' operators. I completed the function for '+' and '-' as well,
so that a user can't enter any operator on a blank screen (without any first number).

Please merge this PR.