### PR TITLE
Backspace Functionality Improvement

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                 </div>
                 <div class="padding-functions"></div>
                 <div class="functions-two">
-                    <button class="button backspace" onclick="backspace()" data-text="backspace">
+                    <button class="button backspace" data-text="backspace">
                         <h1>⌫</h1>
                     </button>
                     <button class="button basic-stuff" data-text="+">


### PR DESCRIPTION
Issue Resolved:
 Previously, clicking the backspace button removed two digits instead of the intended single digit in the calculator.
 
Solution Implemented:
 removed onclick function from html which was trigering the function twice : hence removing two elements